### PR TITLE
syntax/c: add noreturn, NULL and <stdbool.h>

### DIFF
--- a/syntax/languages/c.go
+++ b/syntax/languages/c.go
@@ -71,6 +71,7 @@ func cIdentifierOrKeywordParseFunc() parser.Func {
 		"struct", "switch", "typedef", "union", "unsigned",
 		"void", "volatile", "while",
 		"inline", "_Bool", "_Complex", "_Imaginary",
+		"noreturn", "_Noreturn", "NULL", "bool", "true", "false",
 		"__FUNCTION__", "__PRETTY_FUNCTION__", "__alignof", "__alignof__", "__asm",
 		"__asm__", "__attribute", "__attribute__", "__builtin_offsetof",
 		"__builtin_va_arg", "__complex", "__complex__", "__const",


### PR DESCRIPTION
<!--
Thank you for contributing code to aretext!  Please fill out questions below.
-->

Description
-----------

This adds `noreturn` (`_Noreturn`), `NULL`, `bool` and `true`/`false` keywords for C syntax highlighter. `_Noreturn` is default in C11 (with `noreturn` from `stdnoreturn.h`), and later come from `stddef.h` and `stdbool.h` respectively. Those are used very commonly, and it makes sense to have them as keywords.

Issue
-----

NULL

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/aretext/aretext/blob/main/CONTRIBUTING.md)
- [x] I have added tests for new features or bug fixes in this PR.
- [x] I have updated any related documentation (markdown files in the "docs" directory).
- [x] I have run `make` and checked in any changes to generated code.
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have formatted all commit messages in the same style as [the other commits in the repository](https://github.com/aretext/aretext/commits/).
- [x] I have added a "Signed-off-by" trailer in all commit messages (`git commit -s`) to indicate my agreement with the [Developer Certificate of Origin](https://developercertificate.org/).
