### PR TITLE
Use `T.TempDir` to create temporary test directory

### DIFF
--- a/file/load_test.go
+++ b/file/load_test.go
@@ -33,8 +33,7 @@ func TestLoad(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			filePath, cleanup := createTestFile(t, tc.fileContents)
-			defer cleanup()
+			filePath := createTestFile(t, tc.fileContents)
 
 			tree, watcher, err := Load(filePath, time.Second)
 			require.NoError(t, err)

--- a/file/save_test.go
+++ b/file/save_test.go
@@ -12,26 +12,19 @@ import (
 )
 
 func TestSaveNewFile(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
-	defer func() {
-		err := os.RemoveAll(tmpDir)
-		require.NoError(t, err)
-	}()
+	tmpDir := t.TempDir()
 
 	path := path.Join(tmpDir, "test.txt")
 	saveAndAssertContents(t, path, "abcd1234", 0644)
 }
 
 func TestSaveModifyExistingFile(t *testing.T) {
-	path, cleanup := createTestFile(t, "old contents")
-	defer cleanup()
+	path := createTestFile(t, "old contents")
 	saveAndAssertContents(t, path, "new contents", 0644)
 }
 
 func TestSaveModifyExistingFilePreservePermissions(t *testing.T) {
-	path, cleanup := createTestFile(t, "old contents")
-	defer cleanup()
+	path := createTestFile(t, "old contents")
 
 	err := os.Chmod(path, 0600)
 	require.NoError(t, err)

--- a/file/watcher_test.go
+++ b/file/watcher_test.go
@@ -13,9 +13,8 @@ import (
 
 const testWatcherPollInterval time.Duration = time.Millisecond * 50
 
-func createTestFile(t *testing.T, s string) (string, func()) {
-	tmpDir, err := os.MkdirTemp("", "")
-	require.NoError(t, err)
+func createTestFile(t *testing.T, s string) string {
+	tmpDir := t.TempDir()
 
 	filePath := path.Join(tmpDir, "test.txt")
 	f, err := os.Create(filePath)
@@ -25,12 +24,7 @@ func createTestFile(t *testing.T, s string) (string, func()) {
 	_, err = io.WriteString(f, s)
 	require.NoError(t, err)
 
-	cleanupFunc := func() {
-		err := os.RemoveAll(tmpDir)
-		require.NoError(t, err)
-	}
-
-	return filePath, cleanupFunc
+	return filePath
 }
 
 func appendToTestFile(t *testing.T, path string, s string) {
@@ -68,8 +62,7 @@ func waitForChangeOrTimeout(t *testing.T, watcher *Watcher) {
 
 func TestWatcher(t *testing.T) {
 	// Create a test file in a temporary directory.
-	filePath, cleanup := createTestFile(t, "abcd")
-	defer cleanup()
+	filePath := createTestFile(t, "abcd")
 
 	// Load the file and start a watcher.
 	_, watcher, err := Load(filePath, testWatcherPollInterval)

--- a/state/document_test.go
+++ b/state/document_test.go
@@ -311,9 +311,7 @@ func TestAbortIfFileExistsWithChangedContent(t *testing.T) {
 }
 
 func TestAbortIfFileExistsWithChangedContentNewFile(t *testing.T) {
-	dir, err := os.MkdirTemp("", "aretext")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	path := filepath.Join(dir, "aretext-does-not-exist")
 	state := NewEditorState(100, 100, nil, nil)

--- a/state/shellcmd_test.go
+++ b/state/shellcmd_test.go
@@ -303,9 +303,7 @@ func setupShellCmdTest(t *testing.T, f func(*EditorState, string)) {
 	suspendScreenFunc := func(f func() error) error { return f() }
 	state := NewEditorState(100, 100, nil, suspendScreenFunc)
 
-	dir, err := os.MkdirTemp("", "aretext")
-	require.NoError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	f(state, dir)
 }


### PR DESCRIPTION
Description
-----------

A testing cleanup.

This pull request replaces `os.MkdirTemp` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir


Issue
-----

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/aretext/aretext/blob/main/CONTRIBUTING.md)
- [ ] I have added tests for new features or bug fixes in this PR.
- [ ] I have updated any related documentation (markdown files in the "docs" directory).
- [x] I have run `make` and checked in any changes to generated code.
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have formatted all commit messages in the same style as [the other commits in the repository](https://github.com/aretext/aretext/commits/).
- [x] I have added a "Signed-off-by" trailer in all commit messages (`git commit -s`) to indicate my agreement with the [Developer Certificate of Origin](https://developercertificate.org/).
