### PR TITLE
Add support for "W".

### DIFF
--- a/input/actions.go
+++ b/input/actions.go
@@ -58,7 +58,15 @@ func CursorDown(count uint64) Action {
 func CursorNextWordStart(count uint64) Action {
 	return func(s *state.EditorState) {
 		state.MoveCursor(s, func(params state.LocatorParams) uint64 {
-			return locate.NextWordStart(params.TextTree, params.CursorPos, count, false)
+			return locate.NextWordStart(params.TextTree, params.CursorPos, count, false, false)
+		})
+	}
+}
+
+func CursorNextBlankSeparatedWordStart(count uint64) Action {
+	return func(s *state.EditorState) {
+		state.MoveCursor(s, func(params state.LocatorParams) uint64 {
+			return locate.NextWordStart(params.TextTree, params.CursorPos, count, false, true)
 		})
 	}
 }
@@ -444,7 +452,7 @@ func DeleteToStartOfLineNonWhitespace(clipboardPage clipboard.PageId) Action {
 func DeleteToStartOfNextWord(count uint64, clipboardPage clipboard.PageId) Action {
 	return func(s *state.EditorState) {
 		state.DeleteToPos(s, func(params state.LocatorParams) uint64 {
-			endPos := locate.NextWordStart(params.TextTree, params.CursorPos, count, true)
+			endPos := locate.NextWordStart(params.TextTree, params.CursorPos, count, true, false)
 			if endPos == params.CursorPos {
 				// The cursor didn't move, so we're on an empty line.
 				// Attempt to delete the newline at the end of the line.
@@ -559,7 +567,7 @@ func CopyToStartOfNextWord(count uint64, clipboardPage clipboard.PageId) Action 
 	return func(s *state.EditorState) {
 		state.CopyRange(s, clipboardPage, func(params state.LocatorParams) (uint64, uint64) {
 			startPos := params.CursorPos
-			endPos := locate.NextWordStart(params.TextTree, params.CursorPos, count, true)
+			endPos := locate.NextWordStart(params.TextTree, params.CursorPos, count, true, false)
 			return startPos, endPos
 		})
 	}

--- a/input/commands.go
+++ b/input/commands.go
@@ -106,6 +106,15 @@ func cursorCommands() []Command {
 			},
 		},
 		{
+			Name: "cursor next blank-separated word start (W)",
+			BuildExpr: func() vm.Expr {
+				return cmdExpr("W", "", captureOpts{count: true})
+			},
+			BuildAction: func(ctx Context, p CommandParams) Action {
+				return decorate(CursorNextBlankSeparatedWordStart(p.Count))
+			},
+		},
+		{
 			Name: "cursor prev word start (b)",
 			BuildExpr: func() vm.Expr {
 				return cmdExpr("b", "", captureOpts{count: true})

--- a/locate/word.go
+++ b/locate/word.go
@@ -12,7 +12,7 @@ import (
 //  1. at the first non-whitespace after a whitespace
 //  2. at the start of an empty line
 //  3. between punctuation and non-punctuation
-func NextWordStart(textTree *text.Tree, pos uint64, targetCount uint64, stopAtEndOfLastLine bool) uint64 {
+func NextWordStart(textTree *text.Tree, pos uint64, targetCount uint64, stopAtEndOfLastLine bool, blankSeparated bool) uint64 {
 	if targetCount == 0 {
 		return pos
 	}
@@ -29,7 +29,7 @@ func NextWordStart(textTree *text.Tree, pos uint64, targetCount uint64, stopAtEn
 	}
 	prevHasNewline := gc.HasNewline()
 	prevWasWhitespace := gc.IsWhitespace()
-	prevWasPunct := isPunct(gc)
+	prevWasWordBoundary := !blankSeparated && isPunct(gc)
 
 	if stopAtEndOfLastLine && targetCount == 1 && prevHasNewline {
 		return pos
@@ -47,11 +47,11 @@ func NextWordStart(textTree *text.Tree, pos uint64, targetCount uint64, stopAtEn
 
 		isWhitespace := gc.IsWhitespace()
 		hasNewline := gc.HasNewline()
-		isPunct := isPunct(gc)
+		isWordBoundary := !blankSeparated && isPunct(gc)
 
 		if (prevWasWhitespace && !isWhitespace) ||
-			(prevWasPunct && !isPunct && !isWhitespace) ||
-			(!prevWasPunct && isPunct) ||
+			(prevWasWordBoundary && !isWordBoundary && !isWhitespace) ||
+			(!prevWasWordBoundary && isWordBoundary) ||
 			(prevHasNewline && hasNewline) {
 			count++
 		}
@@ -67,7 +67,7 @@ func NextWordStart(textTree *text.Tree, pos uint64, targetCount uint64, stopAtEn
 		pos += gc.NumRunes()
 		prevHasNewline = hasNewline
 		prevWasWhitespace = isWhitespace
-		prevWasPunct = isPunct
+		prevWasWordBoundary = isWordBoundary
 	}
 
 	return pos

--- a/locate/word_test.go
+++ b/locate/word_test.go
@@ -162,7 +162,7 @@ func TestNextWordStart(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			textTree, err := text.NewTreeFromString(tc.inputString)
 			require.NoError(t, err)
-			actualPos := NextWordStart(textTree, tc.pos, tc.count, tc.stopAtEndOfLastLine)
+			actualPos := NextWordStart(textTree, tc.pos, tc.count, tc.stopAtEndOfLastLine, false)
 			assert.Equal(t, tc.expectedPos, actualPos)
 		})
 	}


### PR DESCRIPTION
Description
-----------

The set of key bindings "W", "E", and "B" are similar to their equivalent lower case variants, but word separators are whitespace only. 

This seemed like it would be fairly straightforward, but after adding  the "W" command two things occur that I don't know how to fix:

1. Many keys in normal mode now no longer work at all, including ":" to get into command mode.
2. Hundreds of tests fail. This seems like it may be related to the ordering of tests, but I'm not sure what the solution is. eg.

        interpreter_test.go:2031: 
        	Error Trace:	/Users/aat/Projects/aretext/input/interpreter_test.go:2031
        	Error:      	Not equal: 
        	            	expected: 0x8
        	            	actual  : 0x0
        	Test:       	TestInterpreterStateIntegration/cursor_back
    --- FAIL: TestInterpreterStateIntegration/cursor_back (0.00s)


If the solution is something minor, I'd be interested in continuing.

Checklist
---------

- [ ] I have read the [Contribution Guidelines](https://github.com/aretext/aretext/blob/main/CONTRIBUTING.md)
- [ ] I have added tests for new features or bug fixes in this PR.
- [ ] I have updated any related documentation (markdown files in the "docs" directory).
- [ ] I have run `make` and checked in any changes to generated code.
- [ ] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have formatted all commit messages in the same style as [the other commits in the repository](https://github.com/aretext/aretext/commits/).
- [ ] I have added a "Signed-off-by" trailer in all commit messages (`git commit -s`) to indicate my agreement with the [Developer Certificate of Origin](https://developercertificate.org/).
