### PR TITLE
Allow aretext to build on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
         os:
           - "ubuntu-latest"
           - "macos-latest"
+          - "windows-latest"
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/file/save.go
+++ b/file/save.go
@@ -7,41 +7,24 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/renameio/v2"
-
 	"github.com/aretext/aretext/text"
 )
 
 // Save writes the text to disk and starts a new watcher to detect subsequent changes.
 // This adds the POSIX end-of-file indicator (line feed at the end of the file).
 func Save(path string, tree *text.Tree, watcherPollInterval time.Duration) (*Watcher, error) {
-	// Use renameio to write the file to a temporary directory, then rename it to the target file.
-	// This should reduce the risk of data corruption if the editor crashes mid-write,
-	// but is probably not 100% reliable (see http://danluu.com/deconstruct-files/).
-	// There is a good discussion of the Go libraries solving this problem in
-	// this GitHub issue comment: https://github.com/golang/go/issues/22397#issuecomment-380831736
-	pf, err := renameio.NewPendingFile(path, renameio.WithPermissions(0644), renameio.WithExistingPermissions())
-	if err != nil {
-		return nil, fmt.Errorf("renamio.TempFile: %w", err)
-	}
-	defer pf.Cleanup()
-
 	// Compose a reader that calculates the checksum and appends the POSIX EOF indicator.
 	checksummer := NewChecksummer()
 	textReader := tree.ReaderAtPosition(0)
 	posixEofReader := strings.NewReader("\n")
 	r := io.TeeReader(io.MultiReader(&textReader, posixEofReader), checksummer)
 
-	// Write to the file and calculate the checksum.
-	_, err = io.Copy(pf, r)
+	// Save the contents of the reader to a file.
+	// On Linux, this uses renamio. On Windows, this uses the Go stdlib.
+	// This implicitly calculates the checksum.
+	err := platformSpecificSave(path, r)
 	if err != nil {
-		return nil, fmt.Errorf("io.Copy: %w", err)
-	}
-
-	// Sync the file to disk so the watcher calculates the checksum correctly later.
-	err = pf.CloseAtomicallyReplace()
-	if err != nil {
-		return nil, fmt.Errorf("renamio.CloseAtomicallyReplace: %w", err)
+		return nil, err
 	}
 
 	// Start a new watcher for subsequent changes to the file.

--- a/file/save_unix.go
+++ b/file/save_unix.go
@@ -1,0 +1,37 @@
+//go:build !windows
+
+package file
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/google/renameio/v2"
+)
+
+func platformSpecificSave(path string, r io.Reader) error {
+	// Use renameio to write the file to a temporary directory, then rename it to the target file.
+	// This should reduce the risk of data corruption if the editor crashes mid-write,
+	// but is probably not 100% reliable (see http://danluu.com/deconstruct-files/).
+	// There is a good discussion of the Go libraries solving this problem in
+	// this GitHub issue comment: https://github.com/golang/go/issues/22397#issuecomment-380831736
+	pf, err := renameio.NewPendingFile(path, renameio.WithPermissions(0644), renameio.WithExistingPermissions())
+	if err != nil {
+		return fmt.Errorf("renamio.TempFile: %w", err)
+	}
+	defer pf.Cleanup()
+
+	// Copy data from the reader to the file.
+	_, err = io.Copy(pf, r)
+	if err != nil {
+		return fmt.Errorf("io.Copy: %w", err)
+	}
+
+	// Sync the file to disk.
+	err = pf.CloseAtomicallyReplace()
+	if err != nil {
+		return fmt.Errorf("renamio.CloseAtomicallyReplace: %w", err)
+	}
+
+	return nil
+}

--- a/file/save_windows.go
+++ b/file/save_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package file
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+func platformSpecificSave(path string, r io.Reader) error {
+	// renameio is not available on Windows (see https://github.com/google/renameio/pull/20)
+	// so we use the Go stdlib instead.
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("os.Create: %w", err)
+	}
+	defer f.Close()
+
+	_, err = io.Copy(f, r)
+	if err != nil {
+		return fmt.Errorf("io.Copy: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
* Use Go stdlib instead of renamio on Windows
* Add Windows to CI build matrix