### PR TITLE
Add Elixir syntax language

### DIFF
--- a/app/default-config.yaml
+++ b/app/default-config.yaml
@@ -193,6 +193,19 @@
     tabSize: 4
     showLineNumbers: true
 
+- name: elixir
+  pattern: "**/*.ex"
+  config: &elixirConfig
+    autoIndent: true
+    syntaxLanguage: elixir
+    tabExpand: true
+    tabSize: 2
+    showLineNumbers: true
+
+- name: elixir-script
+  pattern: "**/*.exs"
+  config: *elixirConfig
+
 - name: xml
   pattern: "**/*.xml"
   config: &xmlconfig

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -29,6 +29,7 @@ Syntax Languages
 | c            | [C](http://www.gnu.org/software/gnu-c-manual/gnu-c-manual.html)                             |
 | criticmarkup | [CriticMarkup](https://github.com/CriticMarkup/CriticMarkup-toolkit)                        |
 | dockerfile   | [Dockerfile](https://docs.docker.com/reference/dockerfile)                                  |
+| elixir       | [Elixir](https://hexdocs.pm/elixir/syntax-reference.html)                                   |
 | gitcommit    | Format for editing a git commit                                                             |
 | gitrebase    | Format for git interactive rebase                                                           |
 | go           | [Go](https://golang.org/ref/spec)                                                           |

--- a/syntax/languages/elixir.go
+++ b/syntax/languages/elixir.go
@@ -1,0 +1,200 @@
+package languages
+
+import (
+	"unicode"
+
+	"github.com/aretext/aretext/syntax/parser"
+)
+
+const (
+	elixirTokenRoleAtom      = parser.TokenRoleCustom1
+	elixirTokenRoleAttribute = parser.TokenRoleCustom2
+)
+
+// ElixirParseFunc returns a parse func for Elixir.
+// See "Elixir Syntax Reference"
+// https://hexdocs.pm/elixir/syntax-reference.html
+func ElixirParseFunc() parser.Func {
+	return elixirCommentParseFunc().
+		Or(elixirCharParseFunc()).
+		Or(elixirSigilParseFunc()).
+		Or(elixirStringParseFunc()).
+		Or(elixirAtomParseFunc()).
+		Or(elixirAttributeParseFunc()).
+		Or(elixirNumberParseFunc()).
+		Or(elixirIdentifierOrKeywordParseFunc()).
+		Or(elixirOperatorParseFunc())
+}
+
+func elixirCommentParseFunc() parser.Func {
+	return consumeString("#").
+		ThenMaybe(consumeToNextLineFeed).
+		Map(recognizeToken(parser.TokenRoleComment))
+}
+
+// elixirCharParseFunc parses a character code like `?a` or `?\n`.
+func elixirCharParseFunc() parser.Func {
+	consumeEscaped := consumeString(`\`).
+		Then(consumeSingleRuneLike(func(r rune) bool { return r != '\n' }))
+	consumeUnescaped := consumeSingleRuneLike(func(r rune) bool {
+		return !unicode.IsSpace(r)
+	})
+	return consumeString("?").
+		Then(consumeEscaped.Or(consumeUnescaped)).
+		Map(recognizeToken(parser.TokenRoleNumber))
+}
+
+// elixirSigilParseFunc parses a sigil like `~r/.../` or `~w[foo bar]a`.
+func elixirSigilParseFunc() parser.Func {
+	consumeName := consumeString("~").
+		Then(consumeSingleRuneLike(unicode.IsLetter)).
+		ThenMaybe(consumeRunesLike(unicode.IsLetter))
+
+	// Paired delimiters do not track nesting, which is good enough for highlighting.
+	consumeDelimited := consumeString("(").Then(consumeToString(")")).
+		Or(consumeString("[").Then(consumeToString("]"))).
+		Or(consumeString("{").Then(consumeToString("}"))).
+		Or(consumeString("<").Then(consumeToString(">"))).
+		Or(consumeString("/").Then(consumeToString("/"))).
+		Or(consumeString("|").Then(consumeToString("|"))).
+		Or(consumeString(`"`).Then(consumeToString(`"`))).
+		Or(consumeString("'").Then(consumeToString("'")))
+
+	consumeModifiers := consumeRunesLike(func(r rune) bool {
+		return r >= 'a' && r <= 'z'
+	})
+
+	return consumeName.
+		Then(consumeDelimited).
+		ThenMaybe(consumeModifiers).
+		Map(recognizeToken(parser.TokenRoleString))
+}
+
+func elixirStringParseFunc() parser.Func {
+	consumeHeredoc := (consumeString(`"""`).Then(consumeToString(`"""`))).
+		Or(consumeString("'''").Then(consumeToString("'''")))
+	consumeSingleLine := parseCStyleString('"', false).
+		Or(parseCStyleString('\'', false))
+	return consumeHeredoc.
+		Or(consumeSingleLine).
+		Map(recognizeToken(parser.TokenRoleString))
+}
+
+// elixirAtomParseFunc parses an atom like `:ok`, `:"with spaces"`, or `:valid?`.
+func elixirAtomParseFunc() parser.Func {
+	isAtomStart := func(r rune) bool {
+		return r == '_' || unicode.IsLetter(r)
+	}
+	isAtomContinue := func(r rune) bool {
+		return r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)
+	}
+	consumePlainAtom := consumeString(":").
+		Then(consumeSingleRuneLike(isAtomStart)).
+		ThenMaybe(consumeRunesLike(isAtomContinue)).
+		ThenMaybe(consumeSingleRuneLike(func(r rune) bool {
+			return r == '?' || r == '!'
+		}))
+	consumeQuotedAtom := consumeString(":").
+		Then(parseCStyleString('"', false).Or(parseCStyleString('\'', false)))
+	return consumePlainAtom.
+		Or(consumeQuotedAtom).
+		Map(recognizeToken(elixirTokenRoleAtom))
+}
+
+// elixirAttributeParseFunc parses a module attribute like `@moduledoc` or `@spec`.
+func elixirAttributeParseFunc() parser.Func {
+	isIdentStart := func(r rune) bool {
+		return r == '_' || unicode.IsLetter(r)
+	}
+	isIdentContinue := func(r rune) bool {
+		return r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)
+	}
+	return consumeString("@").
+		Then(consumeSingleRuneLike(isIdentStart)).
+		ThenMaybe(consumeRunesLike(isIdentContinue)).
+		Map(recognizeToken(elixirTokenRoleAttribute))
+}
+
+func elixirNumberParseFunc() parser.Func {
+	consumeDecimalDigits := consumeSingleRuneLike(func(r rune) bool {
+		return r >= '0' && r <= '9'
+	}).ThenMaybe(consumeDigitsAndSeparators(true, func(r rune) bool {
+		return r >= '0' && r <= '9'
+	}))
+
+	consumeHexLiteral := (consumeString("0x").Or(consumeString("0X"))).
+		Then(consumeDigitsAndSeparators(true, func(r rune) bool {
+			return (r >= '0' && r <= '9') || (r >= 'a' && r <= 'f') || (r >= 'A' && r <= 'F')
+		}))
+
+	consumeOctalLiteral := (consumeString("0o").Or(consumeString("0O"))).
+		Then(consumeDigitsAndSeparators(true, func(r rune) bool {
+			return r >= '0' && r <= '7'
+		}))
+
+	consumeBinaryLiteral := (consumeString("0b").Or(consumeString("0B"))).
+		Then(consumeDigitsAndSeparators(true, func(r rune) bool {
+			return r == '0' || r == '1'
+		}))
+
+	// Elixir floats require digits on both sides of the point, and an exponent
+	// is only valid on a float.
+	consumeExponent := (consumeString("e").Or(consumeString("E"))).
+		ThenMaybe(consumeString("+").Or(consumeString("-"))).
+		Then(consumeDecimalDigits)
+	consumeFloatLiteral := consumeDecimalDigits.
+		Then(consumeString(".")).
+		Then(consumeDecimalDigits).
+		ThenMaybe(consumeExponent)
+
+	return consumeHexLiteral.
+		Or(consumeOctalLiteral).
+		Or(consumeBinaryLiteral).
+		Or(consumeFloatLiteral).
+		Or(consumeDecimalDigits).
+		Map(recognizeToken(parser.TokenRoleNumber))
+}
+
+func elixirIdentifierOrKeywordParseFunc() parser.Func {
+	isIdentStart := func(r rune) bool {
+		return r == '_' || unicode.IsLetter(r)
+	}
+	isIdentContinue := func(r rune) bool {
+		return r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)
+	}
+
+	keywords := []string{
+		"true", "false", "nil",
+		"when", "and", "or", "not", "in",
+		"fn", "do", "end", "catch", "rescue", "after", "else",
+		"if", "unless", "case", "cond", "for", "with",
+		"try", "receive", "raise", "throw",
+		"def", "defp", "defmodule", "defmacro", "defmacrop",
+		"defstruct", "defprotocol", "defimpl", "defdelegate",
+		"defguard", "defguardp", "defexception", "defoverridable",
+		"import", "alias", "require", "use",
+		"quote", "unquote", "unquote_splicing", "super",
+		"__MODULE__", "__DIR__", "__ENV__", "__CALLER__", "__STACKTRACE__",
+	}
+
+	return consumeSingleRuneLike(isIdentStart).
+		ThenMaybe(consumeRunesLike(isIdentContinue)).
+		ThenMaybe(consumeSingleRuneLike(func(r rune) bool {
+			return r == '?' || r == '!'
+		})).
+		MapWithInput(recognizeKeywordOrConsume(keywords, true))
+}
+
+func elixirOperatorParseFunc() parser.Func {
+	return consumeLongestMatchingOption([]string{
+		".", "..", "...",
+		"+", "-", "*", "/", "**",
+		"++", "--",
+		"==", "!=", "===", "!==", "=~",
+		"<", ">", "<=", ">=",
+		"&&", "||", "!",
+		"&&&", "|||", "^^^", "~~~", "<<<", ">>>",
+		"=", "=>", "->", "<-", "<>", "|>", "|", `\\`,
+		"::", ":", "&", "^", "@", "%",
+	}).Map(recognizeToken(parser.TokenRoleOperator))
+}

--- a/syntax/languages/elixir.go
+++ b/syntax/languages/elixir.go
@@ -50,8 +50,12 @@ func elixirSigilParseFunc() parser.Func {
 		Then(consumeSingleRuneLike(unicode.IsLetter)).
 		ThenMaybe(consumeRunesLike(unicode.IsLetter))
 
+	// Heredoc delimiters must be tried before the single-character `"` and `'`
+	// delimiters so that a sigil like `~S"""..."""` is consumed as one token.
 	// Paired delimiters do not track nesting, which is good enough for highlighting.
-	consumeDelimited := consumeString("(").Then(consumeToString(")")).
+	consumeDelimited := consumeString(`"""`).Then(consumeToString(`"""`)).
+		Or(consumeString("'''").Then(consumeToString("'''"))).
+		Or(consumeString("(").Then(consumeToString(")"))).
 		Or(consumeString("[").Then(consumeToString("]"))).
 		Or(consumeString("{").Then(consumeToString("}"))).
 		Or(consumeString("<").Then(consumeToString(">"))).

--- a/syntax/languages/elixir_test.go
+++ b/syntax/languages/elixir_test.go
@@ -1,0 +1,298 @@
+package languages
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/aretext/aretext/syntax/parser"
+)
+
+func TestElixirParseFunc(t *testing.T) {
+	testCases := []struct {
+		name     string
+		text     string
+		expected []TokenWithText
+	}{
+		{
+			name: "line comment",
+			text: "x = 1 # assign one",
+			expected: []TokenWithText{
+				{Text: "=", Role: parser.TokenRoleOperator},
+				{Text: "1", Role: parser.TokenRoleNumber},
+				{Text: "# assign one", Role: parser.TokenRoleComment},
+			},
+		},
+		{
+			name: "shebang comment",
+			text: "#!/usr/bin/env elixir\n",
+			expected: []TokenWithText{
+				{Text: "#!/usr/bin/env elixir\n", Role: parser.TokenRoleComment},
+			},
+		},
+		{
+			name: "keywords in module definition",
+			text: "defmodule Foo do\nend",
+			expected: []TokenWithText{
+				{Text: "defmodule", Role: parser.TokenRoleKeyword},
+				{Text: "do", Role: parser.TokenRoleKeyword},
+				{Text: "end", Role: parser.TokenRoleKeyword},
+			},
+		},
+		{
+			name: "boolean and nil keywords",
+			text: "a = true\nb = false\nc = nil",
+			expected: []TokenWithText{
+				{Text: "=", Role: parser.TokenRoleOperator},
+				{Text: "true", Role: parser.TokenRoleKeyword},
+				{Text: "=", Role: parser.TokenRoleOperator},
+				{Text: "false", Role: parser.TokenRoleKeyword},
+				{Text: "=", Role: parser.TokenRoleOperator},
+				{Text: "nil", Role: parser.TokenRoleKeyword},
+			},
+		},
+		{
+			name:     "predicate identifier is not a keyword",
+			text:     "valid?",
+			expected: []TokenWithText{},
+		},
+		{
+			name:     "bang identifier is not a keyword",
+			text:     "save!",
+			expected: []TokenWithText{},
+		},
+		{
+			name: "double quoted string",
+			text: `"hello world"`,
+			expected: []TokenWithText{
+				{Text: `"hello world"`, Role: parser.TokenRoleString},
+			},
+		},
+		{
+			name: "double quoted string with escape",
+			text: `"line\nbreak"`,
+			expected: []TokenWithText{
+				{Text: `"line\nbreak"`, Role: parser.TokenRoleString},
+			},
+		},
+		{
+			name: "charlist",
+			text: `'a charlist'`,
+			expected: []TokenWithText{
+				{Text: `'a charlist'`, Role: parser.TokenRoleString},
+			},
+		},
+		{
+			name: "heredoc",
+			text: "\"\"\"\nmultiline\n\"string\"\n\"\"\"",
+			expected: []TokenWithText{
+				{Text: "\"\"\"\nmultiline\n\"string\"\n\"\"\"", Role: parser.TokenRoleString},
+			},
+		},
+		{
+			name: "string interpolation stays within the string token",
+			text: `"count: #{n}"`,
+			expected: []TokenWithText{
+				{Text: `"count: #{n}"`, Role: parser.TokenRoleString},
+			},
+		},
+		{
+			name: "regex sigil with modifier",
+			text: "~r/foo.*bar/i",
+			expected: []TokenWithText{
+				{Text: "~r/foo.*bar/i", Role: parser.TokenRoleString},
+			},
+		},
+		{
+			name: "word list sigil with paired delimiter",
+			text: "~w[one two three]a",
+			expected: []TokenWithText{
+				{Text: "~w[one two three]a", Role: parser.TokenRoleString},
+			},
+		},
+		{
+			name: "string sigil with parens",
+			text: "~s(no # comment here)",
+			expected: []TokenWithText{
+				{Text: "~s(no # comment here)", Role: parser.TokenRoleString},
+			},
+		},
+		{
+			name: "atom",
+			text: ":ok",
+			expected: []TokenWithText{
+				{Text: ":ok", Role: elixirTokenRoleAtom},
+			},
+		},
+		{
+			name: "predicate atom",
+			text: ":valid?",
+			expected: []TokenWithText{
+				{Text: ":valid?", Role: elixirTokenRoleAtom},
+			},
+		},
+		{
+			name: "quoted atom",
+			text: `:"with spaces"`,
+			expected: []TokenWithText{
+				{Text: `:"with spaces"`, Role: elixirTokenRoleAtom},
+			},
+		},
+		{
+			name: "atom in tuple",
+			text: "{:ok, result}",
+			expected: []TokenWithText{
+				{Text: ":ok", Role: elixirTokenRoleAtom},
+			},
+		},
+		{
+			name: "double colon is an operator not an atom",
+			text: "x :: integer",
+			expected: []TokenWithText{
+				{Text: "::", Role: parser.TokenRoleOperator},
+			},
+		},
+		{
+			name: "module attribute",
+			text: "@moduledoc",
+			expected: []TokenWithText{
+				{Text: "@moduledoc", Role: elixirTokenRoleAttribute},
+			},
+		},
+		{
+			name: "attribute with value",
+			text: "@timeout 5000",
+			expected: []TokenWithText{
+				{Text: "@timeout", Role: elixirTokenRoleAttribute},
+				{Text: "5000", Role: parser.TokenRoleNumber},
+			},
+		},
+		{
+			name: "decimal integer with separators",
+			text: "1_000_000",
+			expected: []TokenWithText{
+				{Text: "1_000_000", Role: parser.TokenRoleNumber},
+			},
+		},
+		{
+			name: "hex integer",
+			text: "0xCAFE",
+			expected: []TokenWithText{
+				{Text: "0xCAFE", Role: parser.TokenRoleNumber},
+			},
+		},
+		{
+			name: "octal integer",
+			text: "0o755",
+			expected: []TokenWithText{
+				{Text: "0o755", Role: parser.TokenRoleNumber},
+			},
+		},
+		{
+			name: "binary integer",
+			text: "0b1010",
+			expected: []TokenWithText{
+				{Text: "0b1010", Role: parser.TokenRoleNumber},
+			},
+		},
+		{
+			name: "float",
+			text: "3.14",
+			expected: []TokenWithText{
+				{Text: "3.14", Role: parser.TokenRoleNumber},
+			},
+		},
+		{
+			name: "float with exponent",
+			text: "1.5e-10",
+			expected: []TokenWithText{
+				{Text: "1.5e-10", Role: parser.TokenRoleNumber},
+			},
+		},
+		{
+			name: "range is two numbers around an operator",
+			text: "1..10",
+			expected: []TokenWithText{
+				{Text: "1", Role: parser.TokenRoleNumber},
+				{Text: "..", Role: parser.TokenRoleOperator},
+				{Text: "10", Role: parser.TokenRoleNumber},
+			},
+		},
+		{
+			name: "char code",
+			text: "?a",
+			expected: []TokenWithText{
+				{Text: "?a", Role: parser.TokenRoleNumber},
+			},
+		},
+		{
+			name: "escaped char code",
+			text: `?\n`,
+			expected: []TokenWithText{
+				{Text: `?\n`, Role: parser.TokenRoleNumber},
+			},
+		},
+		{
+			name: "pipe operator",
+			text: "list |> Enum.map(fn x -> x + 1 end)",
+			expected: []TokenWithText{
+				{Text: "|>", Role: parser.TokenRoleOperator},
+				{Text: ".", Role: parser.TokenRoleOperator},
+				{Text: "fn", Role: parser.TokenRoleKeyword},
+				{Text: "->", Role: parser.TokenRoleOperator},
+				{Text: "+", Role: parser.TokenRoleOperator},
+				{Text: "1", Role: parser.TokenRoleNumber},
+				{Text: "end", Role: parser.TokenRoleKeyword},
+			},
+		},
+		{
+			name: "match and concat operators",
+			text: `greeting = "hello" <> name`,
+			expected: []TokenWithText{
+				{Text: "=", Role: parser.TokenRoleOperator},
+				{Text: `"hello"`, Role: parser.TokenRoleString},
+				{Text: "<>", Role: parser.TokenRoleOperator},
+			},
+		},
+		{
+			name: "full function",
+			text: `defmodule Greeter do
+  @greeting "Hello"
+
+  def hello(name) do
+    IO.puts("#{@greeting}, #{name}!")
+    :ok
+  end
+end`,
+			expected: []TokenWithText{
+				{Text: "defmodule", Role: parser.TokenRoleKeyword},
+				{Text: "do", Role: parser.TokenRoleKeyword},
+				{Text: "@greeting", Role: elixirTokenRoleAttribute},
+				{Text: `"Hello"`, Role: parser.TokenRoleString},
+				{Text: "def", Role: parser.TokenRoleKeyword},
+				{Text: "do", Role: parser.TokenRoleKeyword},
+				{Text: ".", Role: parser.TokenRoleOperator},
+				{Text: `"#{@greeting}, #{name}!"`, Role: parser.TokenRoleString},
+				{Text: ":ok", Role: elixirTokenRoleAtom},
+				{Text: "end", Role: parser.TokenRoleKeyword},
+				{Text: "end", Role: parser.TokenRoleKeyword},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			tokens := ParseTokensWithText(ElixirParseFunc(), tc.text)
+			assert.Equal(t, tc.expected, tokens)
+		})
+	}
+}
+
+func BenchmarkElixirParser(b *testing.B) {
+	ParserBenchmark(b, ElixirParseFunc(), "testdata/elixir/example.ex")
+}
+
+func FuzzElixirParseFunc(f *testing.F) {
+	seeds := LoadFuzzTestSeeds(f, "./testdata/elixir/*")
+	ParserFuzzTest(f, ElixirParseFunc(), seeds)
+}

--- a/syntax/languages/elixir_test.go
+++ b/syntax/languages/elixir_test.go
@@ -118,6 +118,13 @@ func TestElixirParseFunc(t *testing.T) {
 			},
 		},
 		{
+			name: "heredoc sigil",
+			text: "~S\"\"\"\nRaw #{not_interpolated} heredoc.\n\"\"\"",
+			expected: []TokenWithText{
+				{Text: "~S\"\"\"\nRaw #{not_interpolated} heredoc.\n\"\"\"", Role: parser.TokenRoleString},
+			},
+		},
+		{
 			name: "atom",
 			text: ":ok",
 			expected: []TokenWithText{

--- a/syntax/languages/testdata/elixir/example.ex
+++ b/syntax/languages/testdata/elixir/example.ex
@@ -1,0 +1,37 @@
+defmodule Store.Inventory do
+  @moduledoc """
+  Tracks items and their quantities.
+  """
+
+  @default_quantity 0
+
+  defstruct items: %{}, name: :unnamed
+
+  @doc "Add a quantity of an item to the inventory."
+  @spec add(t(), atom(), non_neg_integer()) :: t()
+  def add(%__MODULE__{items: items} = inventory, item, amount \\ 1)
+      when is_atom(item) and amount > 0 do
+    updated = Map.update(items, item, amount, &(&1 + amount))
+    %{inventory | items: updated}
+  end
+
+  def count(%__MODULE__{items: items}, item) do
+    Map.get(items, item, @default_quantity)
+  end
+
+  def labels(%__MODULE__{items: items}) do
+    items
+    |> Map.keys()
+    |> Enum.map(fn item -> ~s(item:#{item}) end)
+    |> Enum.sort()
+  end
+
+  # Numbers come in a few shapes.
+  def constants do
+    [0xFF, 0o17, 0b1010, 1_000_000, 3.14, 1.0e-3, ?A]
+  end
+
+  def shout(name) when is_binary(name) do
+    "HELLO, " <> String.upcase(name) <> "!"
+  end
+end

--- a/syntax/languages/testdata/elixir/sigils.ex
+++ b/syntax/languages/testdata/elixir/sigils.ex
@@ -1,0 +1,12 @@
+defmodule Sigils do
+  def examples do
+    words = ~w[alpha beta gamma]
+    pattern = ~r/\d{4}-\d{2}-\d{2}/
+    charlist = ~c(hello)
+    doc = ~S"""
+    Raw #{not_interpolated} heredoc.
+    """
+
+    {words, pattern, charlist, doc}
+  end
+end

--- a/syntax/syntax.go
+++ b/syntax/syntax.go
@@ -33,6 +33,7 @@ const (
 	LanguageSQL          = Language("sql")
 	LanguageTypescript   = Language("typescript")
 	LanguageDockerfile   = Language("dockerfile")
+	LanguageElixir       = Language("elixir")
 )
 
 // languageToParseFunc maps each language to its parse func.
@@ -64,6 +65,7 @@ func init() {
 		LanguageSQL:          languages.SQLParseFunc,
 		LanguageTypescript:   languages.TypescriptParseFunc,
 		LanguageDockerfile:   languages.DockerfileParseFunc,
+		LanguageElixir:       languages.ElixirParseFunc,
 	}
 
 	for language := range languageToParseFuncConstructor {


### PR DESCRIPTION
Closes #217.

This adds an Elixir tokenizer under syntax/languages, wires it into the language registry, and maps `.ex` and `.exs` files to it in the default config. I modeled it on the existing languages, python and rust were the closest fits.

It highlights comments, strings (double quoted, charlists, and heredocs), sigils, atoms, module attributes, char codes, numbers, keywords, and operators. Atoms and module attributes get their own token roles (custom1 and custom2) so they can be styled separately.

Tests cover each of those cases plus a small full example, and there's a benchmark and fuzz test with seed files under testdata/elixir. I ran `go test` and `go test -race` on the package, `go vet`, and `gofmt -s`.

Happy to trim the scope or change the token roles if you'd prefer something simpler.
